### PR TITLE
fix: fix typo - `embedingPathTransform` → `embeddingPathTransform`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,4 +52,4 @@ Mimics Obsidian's link resolution algorithm:
 - `contentRootUrlPrefix` - URL prefix for resolved paths
 - `callout` - Component name, type mapping, prop names
 - `embedRendering` - Custom renderers for note/image/video embeds
-- `embedingPathTransform` / `wikiLinkPathTransform` - URL transformation hooks
+- `embeddingPathTransform` / `wikiLinkPathTransform` - URL transformation hooks

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ export default defineConfig({
           contentRootUrlPrefix: "",
           wikiLinkPathTransform: ({ resolvedUrl }) =>
             resolvedUrl?.replace("/content", ""),
-          embedingPathTransform: ({ resolvedUrl }) =>
+          embeddingPathTransform: ({ resolvedUrl }) =>
             resolvedUrl?.replace("/content", ""),
           callout: {
             componentName: "Callout",
@@ -296,7 +296,7 @@ remark().use(remarkObsidianMdx, {
       children: [],
     }),
   },
-  embedingPathTransform: ({ kind, resolvedUrl }) => {
+  embeddingPathTransform: ({ kind, resolvedUrl }) => {
     if (kind === "image" || kind === "video") {
       return resolvedUrl ?? null;
     }
@@ -337,7 +337,7 @@ remark().use(remarkObsidianMdx, {
 - If `embedRendering.image` is omitted, the plugin emits a standard `image` node with `data.hProperties.width/height` inferred from the file.
 - If `embedRendering.video` is omitted, it emits a `video` MDX JSX node.
 
-### embedingPathTransform
+### embeddingPathTransform
 
 - Overrides resolved URLs for embeds based on embed kind.
 - Returning a string overrides `resolvedUrl`.

--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -782,7 +782,7 @@ test("Should transform resolved embed urls", async () => {
 	const contentRoot = path.resolve(__dirname, "fixtures", "vault");
 	const options = {
 		contentRoot,
-		embedingPathTransform: ({
+		embeddingPathTransform: ({
 			kind,
 			resolvedUrl,
 		}: EmbedPathTransformContext) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ export type PluginOptions = {
 	embedRendering?: EmbedRenderingOptions;
 	contentRoot: string;
 	contentRootUrlPrefix?: string;
-	embedingPathTransform?: (
+	embeddingPathTransform?: (
 		context: EmbedPathTransformContext,
 	) => string | null | undefined;
 	wikiLinkPathTransform?: (
@@ -134,7 +134,7 @@ function plugin(this: any, options: PluginOptions) {
 			embedRendering,
 			contentRoot,
 			contentRootUrlPrefix,
-			embedingPathTransform,
+			embeddingPathTransform,
 			wikiLinkPathTransform,
 		} = options;
 		const resolver = buildContentResolverFromRoot(contentRoot);
@@ -182,7 +182,7 @@ function plugin(this: any, options: PluginOptions) {
 				contentRoot,
 				contentRootUrlPrefix,
 				resolvedPath: resolvedPath ?? undefined,
-				pathTransform: embedingPathTransform,
+				pathTransform: embeddingPathTransform,
 			});
 			const kind = getEmbedKind(target);
 			const isResolved = Boolean(resolvedPath);
@@ -231,7 +231,7 @@ function plugin(this: any, options: PluginOptions) {
 					contentRoot,
 					contentRootUrlPrefix,
 					resolvedPath: resolvedPath ?? undefined,
-					pathTransform: embedingPathTransform,
+					pathTransform: embeddingPathTransform,
 				});
 
 				const rendered = renderEmbedNode({


### PR DESCRIPTION
Just a small typo fix, but it also requires an API change