### PR TITLE
feat: support custom alt text for image embeds via alias syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 > This plugin is inspired by [remark-obsidian](https://github.com/johackim/remark-obsidian)
 
+> Read the blog post: [How I'm Writing MDX with Obsidian](https://mym0404.medium.com/how-im-writing-mdx-with-obsidian-71fa430e65ee)
+
 [![Version](https://img.shields.io/github/tag/mym0404/remark-obsidian-mdx.svg?label=Version&style=flat&colorA=2B323B&colorB=1e2329)](https://github.com/mym0404/remark-obsidian-mdx/releases)
 [![License](https://img.shields.io/badge/license-GPL%20v3%2B-yellow.svg?label=License&style=flat&colorA=2B323B&colorB=1e2329)](https://raw.githubusercontent.com/mym0404/remark-obsidian-mdx/master/LICENSE.txt)
 
@@ -21,6 +23,7 @@ A blog built with this plugin is available at https://english.mjstudio.net, and 
 - `[[Wiki link]]` to mdast `link` nodes (alias divider is `|`)
 - `[[#Heading]]` uses a heading slug
 - `![[Embed]]` to user-provided MDX JSX nodes (note/image/video renderers)
+- `![[image.png|alt text]]` supports custom alt text for image embeds
 - Match notes, embeddings from the contentRoot recursively(mocking Obsidian's algorithm). You don't need to put entire path of resources. Just write [[img.png]]
 
 ## Installation
@@ -277,10 +280,10 @@ remark().use(remarkObsidianMdx, {
       ],
       children: [],
     }),
-    image: ({ target, resolvedUrl, imageWidth, imageHeight }) => ({
+    image: ({ target, resolvedUrl, imageWidth, imageHeight, alias }) => ({
       type: "image",
       url: resolvedUrl ?? target.page,
-      alt: "", // in most cases you might want to derive alt text from some other source
+      alt: alias || "",
       data: {
         hProperties: {
           width: imageWidth ?? 640,
@@ -332,10 +335,10 @@ remark().use(remarkObsidianMdx, {
 
 - Controls how `![[...]]` is rendered. Heading (`#`) and block (`^`) embeds are ignored.
 - Unsupported embed types (non-note/image/video files) are ignored.
-- Receives `resolvedUrl` and `imageWidth`/`imageHeight` when available.
+- Receives `resolvedUrl`, `imageWidth`/`imageHeight`, and `alias` when available.
 - For embeds, `resolvedUrl` includes extensions by default.
 - If a target cannot be resolved under `contentRoot`, the default output is a plain text fallback. You can override this with `embedRendering.notFound`.
-- If `embedRendering.image` is omitted, the plugin emits a standard `image` node with `data.hProperties.width/height` inferred from the file.
+- If `embedRendering.image` is omitted, the plugin emits a standard `image` node with `data.hProperties.width/height` inferred from the file and `alt` set from the alias (e.g., `![[image.png|My alt text]]`).
 - If `embedRendering.video` is omitted, it emits a `video` MDX JSX node.
 
 ### embeddingPathTransform

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -151,11 +151,13 @@ const buildImageNode = ({
 	resolvedUrl,
 	imageWidth,
 	imageHeight,
+	alias,
 }: {
 	target: EmbedTarget;
 	resolvedUrl?: string;
 	imageWidth?: number;
 	imageHeight?: number;
+	alias?: string;
 }) => {
 	const url = resolvedUrl ?? target.page;
 	const hProperties: { width?: number; height?: number } = {};
@@ -170,7 +172,7 @@ const buildImageNode = ({
 	return {
 		type: "image",
 		url,
-		alt: "",
+		alt: alias || "",
 		title: undefined,
 		data:
 			hProperties.width || hProperties.height
@@ -285,6 +287,7 @@ export const renderEmbedNode = ({
 					resolvedUrl: context.resolvedUrl,
 					imageWidth: context.imageWidth,
 					imageHeight: context.imageHeight,
+					alias: context.alias,
 				}));
 
 		return render({


### PR DESCRIPTION
## Summary

- Add support for `![[image.png|alt text]]` syntax to set custom alt text for embedded images
- The alias part after the pipe is now used as the image's alt attribute in the default image renderer
- Add Medium blog post link to README

## Changes

- **src/embed.ts**: Add `alias` parameter to `buildImageNode` function and pass it from the default image renderer
- **__tests__/index.spec.ts**: Add 3 new tests for alt text functionality
- **README.md**: Document the new feature and add blog post link

## Test plan

- [x] Added tests for image embeds with custom alt text
- [x] Added regression test for empty alt text when no alias
- [x] Added test for inline image embeds with alt text
- [x] All 39 tests pass